### PR TITLE
Add NonVBloodMultiplier

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -80,6 +80,7 @@ namespace RPGMods
         private ConfigEntry<int> WeaponDecayInterval;
         private ConfigEntry<int> WeaponMaxMastery;
         private ConfigEntry<float> WeaponMastery_VBloodMultiplier;
+        private ConfigEntry<float> WeaponMastery_NonVBloodMultiplier;
         private ConfigEntry<int> Offline_Weapon_MasteryDecayValue;
         private ConfigEntry<int> MasteryCombatTick;
         private ConfigEntry<int> MasteryMaxCombatTicks;
@@ -149,6 +150,7 @@ namespace RPGMods
             MasteryMaxCombatTicks = Config.Bind("Mastery", "Max Combat Ticks", 12, "Mastery will no longer increase after this many ticks is reached in combat. (1 tick = 5 seconds)");
             WeaponMasterMultiplier = Config.Bind("Mastery", "Mastery Multiplier", 1f, "Multiply the gained mastery value by this amount.");
             WeaponMastery_VBloodMultiplier = Config.Bind("Mastery", "VBlood Mastery Multiplier", 15f, "Multiply Mastery gained from VBlood kill.");
+            WeaponMastery_NonVBloodMultiplier = Config.Bind("Mastery", "Non VBlood Mastery Multiplier", 15f, "Multiply Mastery gained from non VBlood kill.");
             WeaponDecayInterval = Config.Bind("Mastery", "Decay Interval", 60, "Every amount of seconds the user is offline by the configured value will translate as 1 decay tick.");
             Offline_Weapon_MasteryDecayValue = Config.Bind("Mastery", "Decay Value", 1, "Mastery will decay by this amount for every decay tick.(1 -> 0.001%)");
 
@@ -243,6 +245,7 @@ namespace RPGMods
             WeaponMasterSystem.Offline_DecayValue = Offline_Weapon_MasteryDecayValue.Value;
             WeaponMasterSystem.DecayInterval = WeaponDecayInterval.Value;
             WeaponMasterSystem.VBloodMultiplier = WeaponMastery_VBloodMultiplier.Value;
+            WeaponMasterSystem.NonVBloodMultiplier = WeaponMastery_NonVBloodMultiplier.Value;
             WeaponMasterSystem.MasteryMultiplier = WeaponMasterMultiplier.Value;
             WeaponMasterSystem.MaxMastery = WeaponMaxMastery.Value;
             WeaponMasterSystem.MasteryCombatTick = MasteryCombatTick.Value;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -150,7 +150,7 @@ namespace RPGMods
             MasteryMaxCombatTicks = Config.Bind("Mastery", "Max Combat Ticks", 12, "Mastery will no longer increase after this many ticks is reached in combat. (1 tick = 5 seconds)");
             WeaponMasterMultiplier = Config.Bind("Mastery", "Mastery Multiplier", 1f, "Multiply the gained mastery value by this amount.");
             WeaponMastery_VBloodMultiplier = Config.Bind("Mastery", "VBlood Mastery Multiplier", 15f, "Multiply Mastery gained from VBlood kill.");
-            WeaponMastery_NonVBloodMultiplier = Config.Bind("Mastery", "Non VBlood Mastery Multiplier", 15f, "Multiply Mastery gained from non VBlood kill.");
+            WeaponMastery_NonVBloodMultiplier = Config.Bind("Mastery", "Non VBlood Mastery Multiplier", 1f, "Multiply Mastery gained from non VBlood kill.");
             WeaponDecayInterval = Config.Bind("Mastery", "Decay Interval", 60, "Every amount of seconds the user is offline by the configured value will translate as 1 decay tick.");
             Offline_Weapon_MasteryDecayValue = Config.Bind("Mastery", "Decay Value", 1, "Mastery will decay by this amount for every decay tick.(1 -> 0.001%)");
 

--- a/Systems/WeaponMasterSystem.cs
+++ b/Systems/WeaponMasterSystem.cs
@@ -23,6 +23,7 @@ namespace RPGMods.Systems
         public static int Offline_DecayValue = 1;
         public static int MaxMastery = 100000;
         public static float VBloodMultiplier = 15;
+        public static float NonVBloodMultiplier = 1;
 
         private static PrefabGUID vBloodType = new PrefabGUID(1557174542);
 
@@ -56,7 +57,7 @@ namespace RPGMods.Systems
                 isVBlood = false;
             }
 
-            if (isVBlood) MasteryValue = (int)(MasteryValue * VBloodMultiplier);
+            MasteryValue = isVBlood ? (int)(MasteryValue * VBloodMultiplier) : (int)(MasteryValue * NonVBloodMultiplier);
 
             if (em.HasComponent<PlayerCharacter>(Victim))
             {


### PR DESCRIPTION
There's a pretty popular server in Brazil using this plugin and one of the behaviours we've been seeing is that people just rotate bosses instead of actually farming mobs - as it's not really efficient.

By using `MasteryMultiplier`, we would be buffing boss mastery exp as well, so this PR adds a specific config/multiplier for non VBlood targets so we can buff it separately.

LMK if you like it as well, I kept the implementation super simple to be able to adapt if you want - we're only interested on the mastery system atm but I see you also have a similar implementation for the experience system, haven't touched that.

Cheers.