### PR TITLE
Specify PLUGIN_GUID for Harmony instance for explicit ordering.

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -244,7 +244,8 @@ namespace RPGMods
         {
             InitConfig();
             Logger = Log;
-            harmony = Harmony.CreateAndPatchAll(Assembly.GetExecutingAssembly());
+            harmony = new Harmony(Plugin.PLUGIN_GUID);
+            harmony.PatchAll(Assembly.GetExecutingAssembly());
 
             TaskRunner.Initialize();
 


### PR DESCRIPTION
In order to load first in https://github.com/decaprime/VampireCommandFramework/pull/8 I just set an arbitrary number. Ideally I could specify that it loads before this mod. I'm recommending this PR because this is a popular repository others look at for example and I believe this is the best practice to specify:

> The id should be in reverse domain notation and must be unique. In order to understand and react on existing patches of others, all patches in Harmony are bound to that id. This allows other authors to execute their patches before or after a specific patch by referring to this id.

https://harmony.pardeike.net/articles/basics.html#creating-a-harmony-instance
